### PR TITLE
Add scene import from file

### DIFF
--- a/assets/locale/de/LC_MESSAGES/writingway.po
+++ b/assets/locale/de/LC_MESSAGES/writingway.po
@@ -1125,6 +1125,15 @@ msgstr "Szene hinzufügen"
 msgid "Enter scene name:"
 msgstr "Geben Sie den Szenennamen ein:"
 
+#: project_window/project_structure_manager.py:31
+#: project_window/project_tree_widget.py:174
+msgid "Import Scene from File"
+msgstr ""
+
+#: project_window/project_structure_manager.py:33
+msgid "Text/Markdown Files (*.txt *.md)"
+msgstr ""
+
 #: project_window/project_structure_manager.py:34
 msgid "Enter new name:"
 msgstr "Geben Sie den neuen Namen ein:"

--- a/assets/locale/es/LC_MESSAGES/writingway.po
+++ b/assets/locale/es/LC_MESSAGES/writingway.po
@@ -1168,6 +1168,15 @@ msgstr "Añadir Escena"
 msgid "Enter scene name:"
 msgstr "Ingrese el nombre de la escena:"
 
+#: project_window/project_structure_manager.py:31
+#: project_window/project_tree_widget.py:174
+msgid "Import Scene from File"
+msgstr ""
+
+#: project_window/project_structure_manager.py:33
+msgid "Text/Markdown Files (*.txt *.md)"
+msgstr ""
+
 #: project_window/project_structure_manager.py:34
 msgid "Enter new name:"
 msgstr "Ingrese el nuevo nombre:"

--- a/assets/locale/fr/LC_MESSAGES/writingway.po
+++ b/assets/locale/fr/LC_MESSAGES/writingway.po
@@ -1101,6 +1101,15 @@ msgstr "Ajouter une scène"
 msgid "Enter scene name:"
 msgstr "Entrez le nom de la scène :"
 
+#: project_window/project_structure_manager.py:31
+#: project_window/project_tree_widget.py:174
+msgid "Import Scene from File"
+msgstr ""
+
+#: project_window/project_structure_manager.py:33
+msgid "Text/Markdown Files (*.txt *.md)"
+msgstr ""
+
 #: project_window/project_structure_manager.py:34
 msgid "Enter new name:"
 msgstr "Entrez le nouveau nom :"

--- a/assets/locale/ja/LC_MESSAGES/writingway.po
+++ b/assets/locale/ja/LC_MESSAGES/writingway.po
@@ -1160,6 +1160,15 @@ msgstr "シーンを追加"
 msgid "Enter scene name:"
 msgstr "シーン名を入力："
 
+#: project_window/project_structure_manager.py:31
+#: project_window/project_tree_widget.py:174
+msgid "Import Scene from File"
+msgstr ""
+
+#: project_window/project_structure_manager.py:33
+msgid "Text/Markdown Files (*.txt *.md)"
+msgstr ""
+
 #: project_window/project_structure_manager.py:34
 msgid "Enter new name:"
 msgstr "新しい名前を入力："

--- a/assets/locale/ko/LC_MESSAGES/writingway.po
+++ b/assets/locale/ko/LC_MESSAGES/writingway.po
@@ -1153,6 +1153,15 @@ msgstr "장면 추가"
 msgid "Enter scene name:"
 msgstr "장면 이름을 입력하세요:"
 
+#: project_window/project_structure_manager.py:31
+#: project_window/project_tree_widget.py:174
+msgid "Import Scene from File"
+msgstr ""
+
+#: project_window/project_structure_manager.py:33
+msgid "Text/Markdown Files (*.txt *.md)"
+msgstr ""
+
 #: project_window/project_structure_manager.py:34
 msgid "Enter new name:"
 msgstr "새 이름을 입력하세요:"

--- a/assets/locale/pl/LC_MESSAGES/writingway.po
+++ b/assets/locale/pl/LC_MESSAGES/writingway.po
@@ -1152,6 +1152,15 @@ msgstr "Dodaj scenę"
 msgid "Enter scene name:"
 msgstr "Wprowadź nazwę sceny:"
 
+#: project_window/project_structure_manager.py:31
+#: project_window/project_tree_widget.py:174
+msgid "Import Scene from File"
+msgstr ""
+
+#: project_window/project_structure_manager.py:33
+msgid "Text/Markdown Files (*.txt *.md)"
+msgstr ""
+
 #: project_window/project_structure_manager.py:34
 msgid "Enter new name:"
 msgstr "Wprowadź nową nazwę:"

--- a/assets/locale/pt/LC_MESSAGES/writingway.po
+++ b/assets/locale/pt/LC_MESSAGES/writingway.po
@@ -1163,6 +1163,15 @@ msgstr "Adicionar Cena"
 msgid "Enter scene name:"
 msgstr "Insira o nome da cena:"
 
+#: project_window/project_structure_manager.py:31
+#: project_window/project_tree_widget.py:174
+msgid "Import Scene from File"
+msgstr ""
+
+#: project_window/project_structure_manager.py:33
+msgid "Text/Markdown Files (*.txt *.md)"
+msgstr ""
+
 #: project_window/project_structure_manager.py:34
 msgid "Enter new name:"
 msgstr "Insira o novo nome:"

--- a/assets/locale/ru/LC_MESSAGES/writingway.po
+++ b/assets/locale/ru/LC_MESSAGES/writingway.po
@@ -1103,6 +1103,15 @@ msgstr "Добавить сцену"
 msgid "Enter scene name:"
 msgstr "Введите имя сцены:"
 
+#: project_window/project_structure_manager.py:31
+#: project_window/project_tree_widget.py:174
+msgid "Import Scene from File"
+msgstr ""
+
+#: project_window/project_structure_manager.py:33
+msgid "Text/Markdown Files (*.txt *.md)"
+msgstr ""
+
 #: project_window/project_structure_manager.py:34
 msgid "Enter new name:"
 msgstr "Введите новое имя:"

--- a/assets/locale/writingway.pot
+++ b/assets/locale/writingway.pot
@@ -1129,6 +1129,15 @@ msgstr ""
 msgid "Enter scene name:"
 msgstr ""
 
+#: project_window/project_structure_manager.py:31
+#: project_window/project_tree_widget.py:174
+msgid "Import Scene from File"
+msgstr ""
+
+#: project_window/project_structure_manager.py:33
+msgid "Text/Markdown Files (*.txt *.md)"
+msgstr ""
+
 #: project_window/project_structure_manager.py:34
 msgid "Enter new name:"
 msgstr ""

--- a/assets/locale/zh/LC_MESSAGES/writingway.po
+++ b/assets/locale/zh/LC_MESSAGES/writingway.po
@@ -1143,6 +1143,15 @@ msgstr "添加场景"
 msgid "Enter scene name:"
 msgstr "输入场景名称："
 
+#: project_window/project_structure_manager.py:31
+#: project_window/project_tree_widget.py:174
+msgid "Import Scene from File"
+msgstr ""
+
+#: project_window/project_structure_manager.py:33
+msgid "Text/Markdown Files (*.txt *.md)"
+msgstr ""
+
 #: project_window/project_structure_manager.py:34
 msgid "Enter new name:"
 msgstr "输入新名称："

--- a/project_window/project_structure_manager.py
+++ b/project_window/project_structure_manager.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-from PyQt5.QtWidgets import QInputDialog
+from PyQt5.QtWidgets import QInputDialog, QFileDialog
+import os
 from PyQt5.QtCore import Qt
 
 def add_act(window):
@@ -26,6 +27,30 @@ def add_scene(window, chapter_item):
         act_name = act_item.text(0)
         window.model.add_scene(act_name, chapter_name, text.strip())  # Delegate to ProjectModel
         # No need to update the tree here; ProjectModel emits structureChanged
+
+def add_scene_from_file(window, chapter_item):
+    """Add a new scene using a selected text or markdown file."""
+    file_path, _ = QFileDialog.getOpenFileName(
+        window,
+        _("Import Scene from File"),
+        "",
+        _("Text/Markdown Files (*.txt *.md)")
+    )
+    if file_path:
+        scene_name = os.path.splitext(os.path.basename(file_path))[0]
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                content = f.read()
+        except Exception as e:
+            window.model.errorOccurred.emit(str(e))
+            return
+        chapter_name = chapter_item.text(0)
+        act_item = chapter_item.parent()
+        act_name = act_item.text(0)
+        window.model.add_scene(act_name, chapter_name, scene_name)
+        hierarchy = [act_name, chapter_name, scene_name]
+        window.model.save_scene(hierarchy, content)
+        # StructureChanged emitted by model.add_scene
 
 def rename_item(window, item):
     """Rename a tree item and sync via ProjectModel."""

--- a/project_window/project_tree_widget.py
+++ b/project_window/project_tree_widget.py
@@ -1,5 +1,5 @@
 from gettext import pgettext
-from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QTreeWidget, QMenu, 
+from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QTreeWidget, QMenu,
                              QMessageBox, QInputDialog, QHeaderView)
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QIcon, QFont, QBrush
@@ -173,6 +173,7 @@ class ProjectTreeWidget(QWidget):
                 menu.addAction(_("Add Chapter"), lambda: psm.add_chapter(self.controller, item))
             elif level == 1:
                 menu.addAction(_("Add Scene"), lambda: psm.add_scene(self.controller, item))
+                menu.addAction(_("Import Scene from File"), lambda: psm.add_scene_from_file(self.controller, item))
             if level >= 2:
                 status_menu = menu.addMenu(_("Set Scene Status"))
                 for english_status, translated_status in self.STATUS_MAP.items():


### PR DESCRIPTION
## Summary
- allow importing a scene from a local TXT or Markdown file
- update tree context menu for new option
- update translation template and language files

## Testing
- `python -m py_compile project_window/project_structure_manager.py project_window/project_tree_widget.py`

------
https://chatgpt.com/codex/tasks/task_e_685d15131444832fb67d036bc0a5a38b